### PR TITLE
Fix end-of-line issue on Windows 10

### DIFF
--- a/xlw
+++ b/xlw
@@ -15,6 +15,9 @@ source "${PROG_DIR}/xl/wrapper/wrapper.conf"
 
 XL_WRAPPER_HOME="${HOME}/.xebialabs/wrapper/${CLI_VERSION}"
 
+# remove part of MSWin end of line (when running script from Windows)
+CLI_BASE_URL=${CLI_BASE_URL/$'\r'/}
+
 # checking OS
 BINARY_TYPE="unknown"
 case "`uname`" in
@@ -40,7 +43,7 @@ fi
 XL_BIN="${XL_WRAPPER_HOME}/xl"
 if [ ! -f "${XL_BIN}" ] ; then
   echo "Downloading xl binary to ${XL_BIN}"
-  curl -fLso "${XL_BIN}.$$" "${CLI_BASE_URL/$'\r'/}/${CLI_VERSION}/${BINARY_TYPE}/xl"
+  curl -fLso "${XL_BIN}.$$" "${CLI_BASE_URL}/${CLI_VERSION}/${BINARY_TYPE}/xl"
   chmod +x "${XL_BIN}.$$"
   mv "${XL_BIN}.$$" "${XL_BIN}"
 fi


### PR DESCRIPTION
**Problem:**

While executing `setup.sh` script on Windows 10 error occurs:

![image](https://user-images.githubusercontent.com/37184618/106448055-87b14580-6482-11eb-8bae-86a84df3e0cc.png)

During investigation I found out that this line of code is causing error:
`curl -fLso "${XL_BIN}.$$" "${CLI_BASE_URL}/${CLI_VERSION}/${BINARY_TYPE}/xl"` 

`CLI_BASE_URL` variable contains `\r` (part of MSWin end of line) at the end, which causes URL to be incorrect

**Solution:**
Remove `\r` from `CLI_BASE_URL` variable at the beginning of the script

**Mandatory testing:**

- [x] Check if solution works on other file systems
