### PR TITLE
Changes to allow better integration of this stack into others

### DIFF
--- a/docker-compose-release.yaml
+++ b/docker-compose-release.yaml
@@ -1,9 +1,19 @@
 version: '2.3'
 services:
   xl-release:
+    image: digitalai/continuum-dev-xlrelease
     build: docker/xl-release
     ports:
     - 5516:5516
     environment:
       ADMIN_PASSWORD: admin
       SERVER_URL: http://xl-release:5516
+    volumes:
+      - conf:/opt/xebialabs/xl-release-server/conf
+      - repository:/opt/xebialabs/xl-release-server/repository
+      - archive:/opt/xebialabs/xl-release-server/archive
+
+volumes:
+  conf:
+  repository:
+  archive:

--- a/docker-compose-release.yaml
+++ b/docker-compose-release.yaml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   xl-release:
-    image: digitalai/continuum-dev-xlrelease
+    image: release-delivery-insights-dev
     build: docker/xl-release
     ports:
     - 5516:5516

--- a/docker-compose-setup.yaml
+++ b/docker-compose-setup.yaml
@@ -5,9 +5,22 @@ services:
     build: .
     volumes:
     - ~/.xebialabs/secrets.xlvals:/root/.xebialabs/secrets.xlvals:ro
+    - conf:/opt/xebialabs/xl-release-server/conf
+    - repository:/opt/xebialabs/xl-release-server/repository
+    - archive:/opt/xebialabs/xl-release-server/archive
     command: /bin/sh -c "
       ./xlw apply -d -f /data/setup.yaml"
 
+volumes:
+  conf:
+    external:
+      name: release-delivery-insights-examples_conf
+  repository:
+    external:
+      name: release-delivery-insights-examples_repository
+  archive:
+    external:
+      name: release-delivery-insights-examples_archive
 
 networks:
   default:


### PR DESCRIPTION
Export the volumes which hold Release configuration, repository and
archive data so other stacks can consume them.  Also, give the primary
container name, again so it can be referenced by other compose stacks.